### PR TITLE
Refactor UI to Material3 Expressive

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,12 +11,12 @@ if (keystorePropsFile.exists()) {
 
 android {
     namespace 'com.rosan.accounts'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         applicationId "com.rosan.accounts"
         minSdk 21
-        targetSdk 33
+        targetSdk 34
         versionCode 6
         versionName "1.5"
 
@@ -63,20 +63,20 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
     buildFeatures {
         buildConfig true
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.4.5'
+        kotlinCompilerExtensionVersion '1.5.8'
     }
-    packagingOptions {
+    packaging {
         resources {
             excludes += '/META-INF/{AL2.0,LGPL2.1}'
         }
@@ -84,43 +84,42 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.core:core-ktx:1.10.1'
-    implementation platform('org.jetbrains.kotlin:kotlin-bom:1.8.0')
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.6.1'
-    implementation 'androidx.activity:activity-compose:1.7.2'
-    implementation platform('androidx.compose:compose-bom:2022.10.00')
+    implementation 'androidx.core:core-ktx:1.12.0'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.7.0'
+    implementation 'androidx.activity:activity-compose:1.8.2'
+
+    implementation platform('androidx.compose:compose-bom:2024.02.01')
     implementation 'androidx.compose.ui:ui'
     implementation 'androidx.compose.ui:ui-graphics'
     implementation 'androidx.compose.ui:ui-tooling-preview'
-    implementation 'androidx.compose.material:material'
     implementation 'androidx.compose.material:material-icons-extended'
     implementation 'androidx.compose.material3:material3'
-    testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
-    androidTestImplementation platform('androidx.compose:compose-bom:2022.10.00')
+    implementation 'androidx.compose.material3:material3-window-size-class'
+    androidTestImplementation platform('androidx.compose:compose-bom:2024.02.01')
     androidTestImplementation 'androidx.compose.ui:ui-test-junit4'
     debugImplementation 'androidx.compose.ui:ui-tooling'
     debugImplementation 'androidx.compose.ui:ui-test-manifest'
 
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+
     compileOnly project(':hidden-api')
 
-    implementation 'androidx.navigation:navigation-compose:2.6.0'
+    implementation 'androidx.navigation:navigation-compose:2.7.7'
 
     implementation 'org.lsposed.hiddenapibypass:hiddenapibypass:4.3'
 
-    def accompanist_version = '0.30.1'
+    def accompanist_version = '0.32.0'
     implementation "com.google.accompanist:accompanist-drawablepainter:$accompanist_version"
     implementation "com.google.accompanist:accompanist-navigation-animation:$accompanist_version"
-    implementation "com.google.accompanist:accompanist-insets:$accompanist_version"
-    implementation "com.google.accompanist:accompanist-insets-ui:$accompanist_version"
     implementation "com.google.accompanist:accompanist-systemuicontroller:$accompanist_version"
 
-    implementation 'io.insert-koin:koin-core:3.4.2'
-    implementation 'io.insert-koin:koin-android:3.4.2'
-    implementation 'io.insert-koin:koin-androidx-compose:3.4.5'
+    implementation 'io.insert-koin:koin-core:3.5.3'
+    implementation 'io.insert-koin:koin-android:3.5.3'
+    implementation 'io.insert-koin:koin-androidx-compose:3.5.3'
 
-    def shizuku_version = "13.1.4"
+    def shizuku_version = "13.1.5"
     implementation "dev.rikka.shizuku:api:$shizuku_version"
     implementation "dev.rikka.shizuku:provider:$shizuku_version"
 }

--- a/app/src/main/java/com/rosan/accounts/ui/activity/MainActivity.kt
+++ b/app/src/main/java/com/rosan/accounts/ui/activity/MainActivity.kt
@@ -15,8 +15,10 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         setContent {
             AccountsTheme {
+                // Material3 Expressive 风格：整个应用承载于最低层级的 surface
                 Surface(
-                    modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background
+                    modifier = Modifier.fillMaxSize(),
+                    color = MaterialTheme.colorScheme.surfaceContainerLow
                 ) {
                     MainPage()
                 }

--- a/app/src/main/java/com/rosan/accounts/ui/page/account_manager/AccountManagerPage.kt
+++ b/app/src/main/java/com/rosan/accounts/ui/page/account_manager/AccountManagerPage.kt
@@ -33,6 +33,8 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.LargeTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SuggestionChip
+import androidx.compose.material3.SuggestionChipDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
@@ -45,10 +47,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.google.accompanist.drawablepainter.rememberDrawablePainter
@@ -77,7 +81,7 @@ fun AccountManagerPage(
 
     val context = LocalContext.current
 
-    // Expressive 风格：可折叠大标题
+    // M3 Expressive: 可折叠 LargeTopAppBar
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(
         rememberTopAppBarState()
     )
@@ -89,7 +93,10 @@ fun AccountManagerPage(
         topBar = {
             LargeTopAppBar(
                 title = {
-                    Text(stringResource(R.string.account_manager))
+                    Text(
+                        text = stringResource(R.string.account_manager),
+                        fontWeight = FontWeight.Medium
+                    )
                 },
                 actions = {
                     IconButton(onClick = {
@@ -102,14 +109,16 @@ fun AccountManagerPage(
                     }) {
                         Icon(
                             imageVector = Icons.TwoTone.ContentCopy,
-                            contentDescription = stringResource(R.string.copy_packages_cd)
+                            contentDescription = stringResource(R.string.copy_packages_cd),
+                            modifier = Modifier.size(24.dp)
                         )
                     }
                 },
                 scrollBehavior = scrollBehavior,
                 colors = TopAppBarDefaults.largeTopAppBarColors(
                     containerColor = MaterialTheme.colorScheme.surfaceContainer,
-                    scrolledContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh
+                    scrolledContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                    titleContentColor = MaterialTheme.colorScheme.onSurface
                 )
             )
         },
@@ -130,10 +139,12 @@ fun AccountManagerPage(
             ) {
                 Column(
                     horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                    verticalArrangement = Arrangement.spacedBy(16.dp),
+                    modifier = Modifier.padding(32.dp)
                 ) {
+                    // M3 Expressive 空状态：大圆形容器 + 图标
                     Surface(
-                        modifier = Modifier.size(96.dp),
+                        modifier = Modifier.size(120.dp),
                         shape = CircleShape,
                         color = MaterialTheme.colorScheme.secondaryContainer
                     ) {
@@ -142,13 +153,19 @@ fun AccountManagerPage(
                                 imageVector = Icons.TwoTone.SupervisorAccount,
                                 contentDescription = null,
                                 tint = MaterialTheme.colorScheme.onSecondaryContainer,
-                                modifier = Modifier.size(48.dp)
+                                modifier = Modifier.size(64.dp)
                             )
                         }
                     }
                     Text(
                         text = stringResource(R.string.account_empty),
-                        style = MaterialTheme.typography.titleMedium,
+                        style = MaterialTheme.typography.headlineSmall,
+                        fontWeight = FontWeight.Medium,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                    Text(
+                        text = stringResource(R.string.account_empty_hint),
+                        style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 }
@@ -163,12 +180,12 @@ fun AccountManagerPage(
             LazyColumn(
                 modifier = Modifier.fillMaxSize(),
                 contentPadding = PaddingValues(
-                    start = 16.dp,
-                    end = 16.dp,
-                    top = padding.calculateTopPadding() + 8.dp,
-                    bottom = padding.calculateBottomPadding() + 24.dp
+                    start = 24.dp,
+                    end = 24.dp,
+                    top = padding.calculateTopPadding() + 16.dp,
+                    bottom = padding.calculateBottomPadding() + 32.dp
                 ),
-                verticalArrangement = Arrangement.spacedBy(12.dp)
+                verticalArrangement = Arrangement.spacedBy(20.dp)
             ) {
                 items(viewModel.state.authenticators, key = { it.auth.type }) {
                     var alpha by remember { mutableStateOf(0f) }
@@ -203,24 +220,26 @@ private fun AuthenticatorItemCard(
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
         ),
-        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+        elevation = CardDefaults.cardElevation(
+            defaultElevation = 0.dp
+        )
     ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(20.dp),
+                .padding(24.dp),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(16.dp)
+            horizontalArrangement = Arrangement.spacedBy(20.dp)
         ) {
-            // 应用图标（圆形容器）
+            // 应用图标：primaryContainer 圆形容器
             Surface(
-                modifier = Modifier.size(56.dp),
+                modifier = Modifier.size(72.dp),
                 shape = CircleShape,
                 color = MaterialTheme.colorScheme.primaryContainer
             ) {
                 Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                     Image(
-                        modifier = Modifier.size(32.dp),
+                        modifier = Modifier.size(40.dp),
                         painter = rememberDrawablePainter(authenticator.auth.icon),
                         contentDescription = null
                     )
@@ -230,23 +249,36 @@ private fun AuthenticatorItemCard(
             Column(modifier = Modifier.weight(1f)) {
                 Text(
                     text = authenticator.auth.label,
-                    style = MaterialTheme.typography.titleLarge,
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.Medium,
                     color = MaterialTheme.colorScheme.onSurface
                 )
-                Spacer(Modifier.height(2.dp))
+                Spacer(Modifier.height(4.dp))
                 Text(
                     text = authenticator.auth.type,
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
-                Spacer(Modifier.height(8.dp))
-                Text(
-                    text = stringResource(
-                        R.string.linked_accounts_count,
-                        authenticator.accounts.size
+                Spacer(Modifier.height(12.dp))
+                SuggestionChip(
+                    onClick = { },
+                    label = {
+                        Text(
+                            text = stringResource(
+                                R.string.linked_accounts_count,
+                                authenticator.accounts.size
+                            ),
+                            style = MaterialTheme.typography.labelLarge
+                        )
+                    },
+                    colors = SuggestionChipDefaults.suggestionChipColors(
+                        containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+                        labelColor = MaterialTheme.colorScheme.onTertiaryContainer
                     ),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                    border = SuggestionChipDefaults.suggestionChipBorder(
+                        borderColor = Color.Transparent,
+                        borderWidth = 0.dp
+                    )
                 )
             }
         }

--- a/app/src/main/java/com/rosan/accounts/ui/page/account_manager/AccountManagerPage.kt
+++ b/app/src/main/java/com/rosan/accounts/ui/page/account_manager/AccountManagerPage.kt
@@ -1,9 +1,11 @@
 package com.rosan.accounts.ui.page.account_manager
 
-import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
@@ -11,25 +13,30 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.displayCutout
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.ContentCopy
+import androidx.compose.material.icons.twotone.SupervisorAccount
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LargeTopAppBar
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
@@ -39,6 +46,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -69,12 +77,17 @@ fun AccountManagerPage(
 
     val context = LocalContext.current
 
+    // Expressive 风格：可折叠大标题
+    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(
+        rememberTopAppBarState()
+    )
+
     Scaffold(
         modifier = Modifier
             .fillMaxSize()
-            .windowInsetsPadding(WindowInsets.displayCutout),
+            .nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
-            TopAppBar(
+            LargeTopAppBar(
                 title = {
                     Text(stringResource(R.string.account_manager))
                 },
@@ -89,57 +102,90 @@ fun AccountManagerPage(
                     }) {
                         Icon(
                             imageVector = Icons.TwoTone.ContentCopy,
-                            contentDescription = null
+                            contentDescription = stringResource(R.string.copy_packages_cd)
                         )
                     }
-                }
+                },
+                scrollBehavior = scrollBehavior,
+                colors = TopAppBarDefaults.largeTopAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceContainer,
+                    scrolledContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh
+                )
             )
         },
-    ) {
-        AnimatedContent(
-            viewModel.state.authenticators.isEmpty(),
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(it)
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLow
+    ) { padding ->
+        val isEmpty = viewModel.state.authenticators.isEmpty()
+
+        AnimatedVisibility(
+            visible = isEmpty,
+            enter = fadeIn(),
+            exit = fadeOut()
         ) {
-            if (it) {
-                Box(
-                    modifier = Modifier.fillMaxSize()
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding),
+                contentAlignment = Alignment.Center
+            ) {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
                 ) {
-                    Text(
-                        stringResource(R.string.account_empty),
-                        modifier = Modifier.align(Alignment.Center)
-                    )
-                }
-            } else {
-                LazyColumn(
-                    modifier = Modifier.fillMaxSize(),
-                    contentPadding = PaddingValues(16.dp),
-                    verticalArrangement = Arrangement.spacedBy(16.dp)
-                ) {
-                    items(viewModel.state.authenticators, key = {
-                        it.auth.type
-                    }) {
-                        var alpha by remember {
-                            mutableStateOf(0f)
-                        }
-                        ItemWidget(
-                            modifier = Modifier
-                                .fillMaxWidth()
-//                                .clip(RoundedCornerShape(8.dp))
-                                .animateItemPlacement()
-                                .graphicsLayer(
-                                    alpha = animateFloatAsState(
-                                        targetValue = alpha,
-                                        animationSpec = spring(stiffness = 100f)
-                                    ).value
-                                ),
-                            authenticator = it
-                        )
-                        SideEffect {
-                            alpha = 1f
+                    Surface(
+                        modifier = Modifier.size(96.dp),
+                        shape = CircleShape,
+                        color = MaterialTheme.colorScheme.secondaryContainer
+                    ) {
+                        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                            Icon(
+                                imageVector = Icons.TwoTone.SupervisorAccount,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                                modifier = Modifier.size(48.dp)
+                            )
                         }
                     }
+                    Text(
+                        text = stringResource(R.string.account_empty),
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        }
+
+        AnimatedVisibility(
+            visible = !isEmpty,
+            enter = fadeIn(),
+            exit = fadeOut()
+        ) {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(
+                    start = 16.dp,
+                    end = 16.dp,
+                    top = padding.calculateTopPadding() + 8.dp,
+                    bottom = padding.calculateBottomPadding() + 24.dp
+                ),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                items(viewModel.state.authenticators, key = { it.auth.type }) {
+                    var alpha by remember { mutableStateOf(0f) }
+                    SideEffect { alpha = 1f }
+                    AuthenticatorItemCard(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .animateItemPlacement()
+                            .graphicsLayer {
+                                this.alpha = animateFloatAsState(
+                                    targetValue = alpha,
+                                    animationSpec = spring(stiffness = 100f),
+                                    label = "auth_alpha"
+                                ).value
+                            },
+                        authenticator = it
+                    )
                 }
             }
         }
@@ -147,26 +193,61 @@ fun AccountManagerPage(
 }
 
 @Composable
-private fun ItemWidget(
+private fun AuthenticatorItemCard(
     modifier: Modifier = Modifier,
     authenticator: AccountManagerViewState.Authenticator
 ) {
-    OutlinedCard(modifier = modifier) {
+    Card(
+        modifier = modifier,
+        shape = MaterialTheme.shapes.large,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+    ) {
         Row(
             modifier = Modifier
-                .padding(horizontal = 24.dp, vertical = 16.dp),
-            horizontalArrangement = Arrangement.spacedBy(24.dp)
+                .fillMaxWidth()
+                .padding(20.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-            Image(
-                modifier = Modifier
-                    .size(32.dp)
-                    .align(Alignment.CenterVertically),
-                painter = rememberDrawablePainter(authenticator.auth.icon),
-                contentDescription = null
-            )
-            Column {
-                Text(authenticator.auth.label, style = MaterialTheme.typography.titleMedium)
-                Text(authenticator.auth.type, style = MaterialTheme.typography.bodyMedium)
+            // 应用图标（圆形容器）
+            Surface(
+                modifier = Modifier.size(56.dp),
+                shape = CircleShape,
+                color = MaterialTheme.colorScheme.primaryContainer
+            ) {
+                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Image(
+                        modifier = Modifier.size(32.dp),
+                        painter = rememberDrawablePainter(authenticator.auth.icon),
+                        contentDescription = null
+                    )
+                }
+            }
+
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = authenticator.auth.label,
+                    style = MaterialTheme.typography.titleLarge,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                Spacer(Modifier.height(2.dp))
+                Text(
+                    text = authenticator.auth.type,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = stringResource(
+                        R.string.linked_accounts_count,
+                        authenticator.accounts.size
+                    ),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
             }
         }
     }

--- a/app/src/main/java/com/rosan/accounts/ui/page/user_manager/UserManagerPage.kt
+++ b/app/src/main/java/com/rosan/accounts/ui/page/user_manager/UserManagerPage.kt
@@ -1,10 +1,12 @@
 package com.rosan.accounts.ui.page.user_manager
 
 import android.os.Process
-import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -12,25 +14,34 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.Delete
+import androidx.compose.material.icons.twotone.Person
 import androidx.compose.material.icons.twotone.Warning
-import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LargeTopAppBar
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
@@ -40,12 +51,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.rosan.accounts.R
 import com.rosan.accounts.data.common.utils.help
-import com.rosan.accounts.data.common.utils.id
 import com.rosan.accounts.data.service.entity.UserEntity
 import com.rosan.accounts.ui.page.main.MainScreen
 import org.koin.androidx.compose.getViewModel
@@ -63,61 +75,94 @@ fun UserManagerPage(
         viewModel.dispatch(UserManagerViewAction.Load)
     }
 
+    // LargeTopAppBar 的滚动行为（Expressive 风格：折叠大标题 → 小标题）
+    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(
+        rememberTopAppBarState()
+    )
+
     Scaffold(
         modifier = Modifier
             .fillMaxSize()
-            .windowInsetsPadding(WindowInsets.displayCutout),
+            .nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
-            TopAppBar(
+            LargeTopAppBar(
                 title = {
-                    Text(stringResource(R.string.user_manager))
-                }
+                    Column {
+                        Text(
+                            text = stringResource(R.string.user_manager),
+                            style = MaterialTheme.typography.headlineMedium,
+                            fontWeight = FontWeight.Medium
+                        )
+                    }
+                },
+                scrollBehavior = scrollBehavior,
+                colors = TopAppBarDefaults.largeTopAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceContainer,
+                    scrolledContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh
+                )
             )
         },
-    ) {
-        AnimatedContent(
-            viewModel.state.cause != null,
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(it)
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLow
+    ) { padding ->
+        AnimatedVisibility(
+            visible = viewModel.state.cause != null,
+            enter = fadeIn(),
+            exit = fadeOut()
         ) {
-            if (it) Box(
-                modifier = Modifier.fillMaxSize()
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding),
+                contentAlignment = Alignment.Center
             ) {
                 Text(
-                    viewModel.state.cause.let {
-                        it?.help() ?: it?.localizedMessage ?: it?.toString() ?: ""
-                    },
-                    modifier = Modifier.align(Alignment.Center)
+                    text = viewModel.state.cause
+                        ?.help()
+                        ?: viewModel.state.cause?.localizedMessage
+                        ?: viewModel.state.cause?.toString()
+                        ?: "",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
-            } else LazyColumn(
+            }
+        }
+
+        AnimatedVisibility(
+            visible = viewModel.state.cause == null,
+            enter = fadeIn(),
+            exit = fadeOut()
+        ) {
+            LazyColumn(
                 modifier = Modifier
                     .fillMaxSize(),
-                contentPadding = PaddingValues(16.dp),
-                verticalArrangement = Arrangement.spacedBy(16.dp)
+                contentPadding = PaddingValues(
+                    start = 16.dp,
+                    end = 16.dp,
+                    top = padding.calculateTopPadding() + 8.dp,
+                    bottom = padding.calculateBottomPadding() + 24.dp
+                ),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
             ) {
-                items(viewModel.state.users, key = {
-                    it.id
-                }) {
-                    var alpha by remember {
-                        mutableStateOf(0f)
-                    }
-                    ItemWidget(
+                items(viewModel.state.users, key = { it.id }) { user ->
+                    var alpha by remember { mutableStateOf(0f) }
+                    SideEffect { alpha = 1f }
+                    UserItemCard(
                         modifier = Modifier
                             .fillMaxWidth()
                             .animateItemPlacement()
-                            .graphicsLayer(
-                                alpha = animateFloatAsState(
+                            .graphicsLayer {
+                                this.alpha = animateFloatAsState(
                                     targetValue = alpha,
-                                    animationSpec = spring(stiffness = 100f)
+                                    animationSpec = spring(stiffness = 100f),
+                                    label = "item_alpha"
                                 ).value
-                            ),
-                        viewModel = viewModel,
-                        navController = navController,
-                        user = it
-                    )
-                    SideEffect {
-                        alpha = 1f
+                            },
+                        user = user,
+                        onOpenAccounts = {
+                            navController.navigate(MainScreen.AccountManager.builder(user.id))
+                        }
+                    ) {
+                        viewModel.dispatch(UserManagerViewAction.Remove(user))
                     }
                 }
             }
@@ -125,101 +170,173 @@ fun UserManagerPage(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun ItemWidget(
+private fun UserItemCard(
     modifier: Modifier = Modifier,
-    viewModel: UserManagerViewModel,
-    navController: NavController,
-    user: UserEntity
+    user: UserEntity,
+    onOpenAccounts: () -> Unit,
+    onRemove: () -> Unit
 ) {
-    OutlinedCard(
-        modifier = modifier
+    val canRemove = Process.myUserHandle().id != user.id
+
+    var showConfirm by remember { mutableStateOf(false) }
+
+    Card(
+        modifier = modifier,
+        shape = MaterialTheme.shapes.large,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
     ) {
         Column(
-            modifier = Modifier.padding(8.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp)
         ) {
             Row(
-                modifier = Modifier
-                    .padding(horizontal = 16.dp)
-                    .padding(top = 8.dp),
+                modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                horizontalArrangement = Arrangement.spacedBy(16.dp)
             ) {
-                Text(
-                    user.id.toString(),
-                    color = MaterialTheme.colorScheme.primary,
-                    style = MaterialTheme.typography.titleMedium
-                )
-                Text(
-                    user.name ?: stringResource(R.string.user_name_default),
-                    style = MaterialTheme.typography.titleMedium
-                )
+                // 圆形头像图标容器（Expressive 风格：高对比 primary container）
+                Surface(
+                    modifier = Modifier
+                        .width(56.dp)
+                        .height(56.dp),
+                    shape = CircleShape,
+                    color = MaterialTheme.colorScheme.primaryContainer
+                ) {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Icon(
+                            imageVector = Icons.TwoTone.Person,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onPrimaryContainer
+                        )
+                    }
+                }
+
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = user.name ?: stringResource(R.string.user_name_default),
+                        style = MaterialTheme.typography.titleLarge,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                    Spacer(Modifier.height(4.dp))
+                    Text(
+                        text = "ID: ${user.id}",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+
+                if (canRemove) {
+                    IconButton(onClick = { showConfirm = true }) {
+                        Icon(
+                            imageVector = Icons.TwoTone.Delete,
+                            contentDescription = stringResource(R.string.remove),
+                            tint = MaterialTheme.colorScheme.error
+                        )
+                    }
+                }
             }
+
+            Spacer(Modifier.height(16.dp))
+
             Row(
-                modifier = Modifier
-                    .padding(horizontal = 8.dp),
+                modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Spacer(modifier = Modifier.weight(1f))
-                TextButton(onClick = {
-                    navController.navigate(MainScreen.AccountManager.builder(user.id))
-                }) {
+                // Expressive 风格 chip：表明"当前用户"状态（或仅装饰）
+                AssistChip(
+                    onClick = { },
+                    leadingIcon = {
+                        Icon(
+                            imageVector = Icons.TwoTone.Person,
+                            contentDescription = null,
+                            modifier = Modifier.height(AssistChipDefaults.IconSize)
+                        )
+                    },
+                    label = {
+                        Text(
+                            text = if (Process.myUserHandle().id == user.id)
+                                stringResource(R.string.current_user_label)
+                            else stringResource(R.string.other_user_label),
+                            style = MaterialTheme.typography.labelLarge
+                        )
+                    },
+                    colors = AssistChipDefaults.assistChipColors(
+                        containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                        labelColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                        leadingIconContentColor = MaterialTheme.colorScheme.onSecondaryContainer
+                    ),
+                    border = null
+                )
+
+                Spacer(Modifier.weight(1f))
+
+                FilledTonalButton(onClick = onOpenAccounts) {
                     Text(stringResource(R.string.account_manager))
-                }
-                val curUserId = Process.myUserHandle().id
-                if (curUserId != user.id) {
-                    var showing by remember {
-                        mutableStateOf(false)
-                    }
-                    TextButton(onClick = { showing = true }) {
-                        Text(stringResource(R.string.remove))
-                    }
-                    DeleteUserDialog(
-                        viewModel = viewModel,
-                        showing = showing,
-                        onDismissRequest = {
-                            showing = false
-                        },
-                        user = user
-                    )
                 }
             }
         }
     }
+
+    if (showConfirm) {
+        RemoveUserDialog(
+            user = user,
+            onDismiss = { showConfirm = false },
+            onConfirm = {
+                onRemove()
+                showConfirm = false
+            }
+        )
+    }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun DeleteUserDialog(
-    viewModel: UserManagerViewModel,
-    showing: Boolean,
-    onDismissRequest: () -> Unit,
-    user: UserEntity
+private fun RemoveUserDialog(
+    user: UserEntity,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit
 ) {
-    if (!showing) return
-    AlertDialog(onDismissRequest = onDismissRequest, icon = {
-        Icon(imageVector = Icons.TwoTone.Warning, contentDescription = null)
-    }, title = {
-        Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
-            Text(
-                user.id.toString(),
-                color = MaterialTheme.colorScheme.primary
+    androidx.compose.material3.AlertDialog(
+        onDismissRequest = onDismiss,
+        icon = {
+            Icon(
+                imageVector = Icons.TwoTone.Warning,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.error
             )
-            Text(user.name ?: stringResource(R.string.user_name_default))
-        }
-    }, text = {
-        Text(stringResource(R.string.delete_user_warning))
-    }, confirmButton = {
-        TextButton(onClick = {
-            viewModel.dispatch(UserManagerViewAction.Remove(user))
-            onDismissRequest()
-        }) {
-            Text(stringResource(R.string.delete_user_confirm))
-        }
-    }, dismissButton = {
-        TextButton(onClick = onDismissRequest) {
-            Text(stringResource(R.string.delete_user_cancel))
-        }
-    })
+        },
+        title = {
+            Text(
+                text = user.name ?: stringResource(R.string.user_name_default),
+                style = MaterialTheme.typography.headlineSmall
+            )
+        },
+        text = {
+            Text(
+                text = stringResource(R.string.delete_user_warning),
+                style = MaterialTheme.typography.bodyMedium
+            )
+        },
+        confirmButton = {
+            FilledTonalButton(onClick = onConfirm) {
+                Text(stringResource(R.string.delete_user_confirm))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.delete_user_cancel))
+            }
+        },
+        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
+    )
 }

--- a/app/src/main/java/com/rosan/accounts/ui/page/user_manager/UserManagerPage.kt
+++ b/app/src/main/java/com/rosan/accounts/ui/page/user_manager/UserManagerPage.kt
@@ -18,16 +18,14 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.twotone.Delete
+import androidx.compose.material.icons.twotone.DeleteOutline
 import androidx.compose.material.icons.twotone.Person
-import androidx.compose.material.icons.twotone.Warning
-import androidx.compose.material3.AssistChip
-import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -37,6 +35,8 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.LargeTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SuggestionChip
+import androidx.compose.material3.SuggestionChipDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -50,6 +50,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
@@ -75,7 +76,7 @@ fun UserManagerPage(
         viewModel.dispatch(UserManagerViewAction.Load)
     }
 
-    // LargeTopAppBar 的滚动行为（Expressive 风格：折叠大标题 → 小标题）
+    // M3 Expressive: 可折叠的 LargeTopAppBar，滚动时标题会缩小
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(
         rememberTopAppBarState()
     )
@@ -87,23 +88,22 @@ fun UserManagerPage(
         topBar = {
             LargeTopAppBar(
                 title = {
-                    Column {
-                        Text(
-                            text = stringResource(R.string.user_manager),
-                            style = MaterialTheme.typography.headlineMedium,
-                            fontWeight = FontWeight.Medium
-                        )
-                    }
+                    Text(
+                        text = stringResource(R.string.user_manager),
+                        fontWeight = FontWeight.Medium
+                    )
                 },
                 scrollBehavior = scrollBehavior,
                 colors = TopAppBarDefaults.largeTopAppBarColors(
                     containerColor = MaterialTheme.colorScheme.surfaceContainer,
-                    scrolledContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh
+                    scrolledContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                    titleContentColor = MaterialTheme.colorScheme.onSurface
                 )
             )
         },
         containerColor = MaterialTheme.colorScheme.surfaceContainerLow
     ) { padding ->
+
         AnimatedVisibility(
             visible = viewModel.state.cause != null,
             enter = fadeIn(),
@@ -115,15 +115,35 @@ fun UserManagerPage(
                     .padding(padding),
                 contentAlignment = Alignment.Center
             ) {
-                Text(
-                    text = viewModel.state.cause
-                        ?.help()
-                        ?: viewModel.state.cause?.localizedMessage
-                        ?: viewModel.state.cause?.toString()
-                        ?: "",
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                    modifier = Modifier.padding(24.dp)
+                ) {
+                    Surface(
+                        modifier = Modifier.size(80.dp),
+                        shape = CircleShape,
+                        color = MaterialTheme.colorScheme.errorContainer
+                    ) {
+                        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                            Icon(
+                                imageVector = Icons.TwoTone.Person,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onErrorContainer,
+                                modifier = Modifier.size(40.dp)
+                            )
+                        }
+                    }
+                    Text(
+                        text = viewModel.state.cause
+                            ?.help()
+                            ?: viewModel.state.cause?.localizedMessage
+                            ?: viewModel.state.cause?.toString()
+                            ?: "",
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
             }
         }
 
@@ -133,15 +153,14 @@ fun UserManagerPage(
             exit = fadeOut()
         ) {
             LazyColumn(
-                modifier = Modifier
-                    .fillMaxSize(),
+                modifier = Modifier.fillMaxSize(),
                 contentPadding = PaddingValues(
-                    start = 16.dp,
-                    end = 16.dp,
-                    top = padding.calculateTopPadding() + 8.dp,
-                    bottom = padding.calculateBottomPadding() + 24.dp
+                    start = 24.dp,
+                    end = 24.dp,
+                    top = padding.calculateTopPadding() + 16.dp,
+                    bottom = padding.calculateBottomPadding() + 32.dp
                 ),
-                verticalArrangement = Arrangement.spacedBy(12.dp)
+                verticalArrangement = Arrangement.spacedBy(20.dp)
             ) {
                 items(viewModel.state.users, key = { it.id }) { user ->
                     var alpha by remember { mutableStateOf(0f) }
@@ -160,10 +179,11 @@ fun UserManagerPage(
                         user = user,
                         onOpenAccounts = {
                             navController.navigate(MainScreen.AccountManager.builder(user.id))
+                        },
+                        onRemove = {
+                            viewModel.dispatch(UserManagerViewAction.Remove(user))
                         }
-                    ) {
-                        viewModel.dispatch(UserManagerViewAction.Remove(user))
-                    }
+                    )
                 }
             }
         }
@@ -179,7 +199,6 @@ private fun UserItemCard(
     onRemove: () -> Unit
 ) {
     val canRemove = Process.myUserHandle().id != user.id
-
     var showConfirm by remember { mutableStateOf(false) }
 
     Card(
@@ -188,34 +207,33 @@ private fun UserItemCard(
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
         ),
-        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+        elevation = CardDefaults.cardElevation(
+            defaultElevation = 0.dp,
+            pressedElevation = 0.dp
+        )
     ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(20.dp)
+                .padding(24.dp)
         ) {
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(16.dp)
+                horizontalArrangement = Arrangement.spacedBy(20.dp)
             ) {
-                // 圆形头像图标容器（Expressive 风格：高对比 primary container）
+                // M3 Expressive: 圆形 primaryContainer 图标容器
                 Surface(
-                    modifier = Modifier
-                        .width(56.dp)
-                        .height(56.dp),
+                    modifier = Modifier.size(72.dp),
                     shape = CircleShape,
                     color = MaterialTheme.colorScheme.primaryContainer
                 ) {
-                    Box(
-                        modifier = Modifier.fillMaxSize(),
-                        contentAlignment = Alignment.Center
-                    ) {
+                    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                         Icon(
                             imageVector = Icons.TwoTone.Person,
                             contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onPrimaryContainer
+                            tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                            modifier = Modifier.size(36.dp)
                         )
                     }
                 }
@@ -223,12 +241,13 @@ private fun UserItemCard(
                 Column(modifier = Modifier.weight(1f)) {
                     Text(
                         text = user.name ?: stringResource(R.string.user_name_default),
-                        style = MaterialTheme.typography.titleLarge,
+                        style = MaterialTheme.typography.headlineSmall,
+                        fontWeight = FontWeight.Medium,
                         color = MaterialTheme.colorScheme.onSurface
                     )
                     Spacer(Modifier.height(4.dp))
                     Text(
-                        text = "ID: ${user.id}",
+                        text = stringResource(R.string.user_id_format, user.id),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
@@ -237,31 +256,25 @@ private fun UserItemCard(
                 if (canRemove) {
                     IconButton(onClick = { showConfirm = true }) {
                         Icon(
-                            imageVector = Icons.TwoTone.Delete,
+                            imageVector = Icons.TwoTone.DeleteOutline,
                             contentDescription = stringResource(R.string.remove),
-                            tint = MaterialTheme.colorScheme.error
+                            tint = MaterialTheme.colorScheme.error,
+                            modifier = Modifier.size(28.dp)
                         )
                     }
                 }
             }
 
-            Spacer(Modifier.height(16.dp))
+            Spacer(Modifier.height(20.dp))
 
             Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                // Expressive 风格 chip：表明"当前用户"状态（或仅装饰）
-                AssistChip(
+                // 状态 chip：表示用户类型
+                SuggestionChip(
                     onClick = { },
-                    leadingIcon = {
-                        Icon(
-                            imageVector = Icons.TwoTone.Person,
-                            contentDescription = null,
-                            modifier = Modifier.height(AssistChipDefaults.IconSize)
-                        )
-                    },
                     label = {
                         Text(
                             text = if (Process.myUserHandle().id == user.id)
@@ -270,18 +283,38 @@ private fun UserItemCard(
                             style = MaterialTheme.typography.labelLarge
                         )
                     },
-                    colors = AssistChipDefaults.assistChipColors(
+                    leadingIcon = {
+                        Icon(
+                            imageVector = Icons.TwoTone.Person,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                            modifier = Modifier.size(SuggestionChipDefaults.IconSize)
+                        )
+                    },
+                    colors = SuggestionChipDefaults.suggestionChipColors(
                         containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                        labelColor = MaterialTheme.colorScheme.onSecondaryContainer,
-                        leadingIconContentColor = MaterialTheme.colorScheme.onSecondaryContainer
+                        labelColor = MaterialTheme.colorScheme.onSecondaryContainer
                     ),
-                    border = null
+                    border = SuggestionChipDefaults.suggestionChipBorder(
+                        borderColor = Color.Transparent,
+                        borderWidth = 0.dp
+                    )
                 )
 
                 Spacer(Modifier.weight(1f))
 
-                FilledTonalButton(onClick = onOpenAccounts) {
-                    Text(stringResource(R.string.account_manager))
+                FilledTonalButton(
+                    onClick = onOpenAccounts,
+                    contentPadding = PaddingValues(
+                        horizontal = 24.dp,
+                        vertical = 12.dp
+                    )
+                ) {
+                    Text(
+                        text = stringResource(R.string.account_manager),
+                        style = MaterialTheme.typography.labelLarge,
+                        fontWeight = FontWeight.Medium
+                    )
                 }
             }
         }
@@ -310,22 +343,41 @@ private fun RemoveUserDialog(
         onDismissRequest = onDismiss,
         icon = {
             Icon(
-                imageVector = Icons.TwoTone.Warning,
+                imageVector = Icons.TwoTone.DeleteOutline,
                 contentDescription = null,
-                tint = MaterialTheme.colorScheme.error
+                tint = MaterialTheme.colorScheme.error,
+                modifier = Modifier.size(36.dp)
             )
         },
         title = {
             Text(
-                text = user.name ?: stringResource(R.string.user_name_default),
-                style = MaterialTheme.typography.headlineSmall
+                text = stringResource(R.string.remove_user_title),
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Medium
             )
         },
         text = {
-            Text(
-                text = stringResource(R.string.delete_user_warning),
-                style = MaterialTheme.typography.bodyMedium
-            )
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text(
+                    text = stringResource(R.string.delete_user_warning),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(Modifier.height(8.dp))
+                Surface(
+                    color = MaterialTheme.colorScheme.primaryContainer,
+                    shape = MaterialTheme.shapes.small,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(
+                        modifier = Modifier.padding(12.dp),
+                        text = "${user.id} — ${user.name ?: stringResource(R.string.user_name_default)}",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer,
+                        fontWeight = FontWeight.Medium
+                    )
+                }
+            }
         },
         confirmButton = {
             FilledTonalButton(onClick = onConfirm) {
@@ -337,6 +389,7 @@ private fun RemoveUserDialog(
                 Text(stringResource(R.string.delete_user_cancel))
             }
         },
+        shape = MaterialTheme.shapes.large,
         containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
     )
 }

--- a/app/src/main/java/com/rosan/accounts/ui/theme/Color.kt
+++ b/app/src/main/java/com/rosan/accounts/ui/theme/Color.kt
@@ -2,10 +2,85 @@ package com.rosan.accounts.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
-val Purple80 = Color(0xFFD0BCFF)
-val PurpleGrey80 = Color(0xFFCCC2DC)
-val Pink80 = Color(0xFFEFB8C8)
+/**
+ * Material3 Expressive 风格预计算种子色。
+ * Expressive 风格使用更鲜艳、对比度更高的主色、次要色、三级色与中性色。
+ * 实际 ColorScheme 将通过 dynamicDarkColorScheme / dynamicLightColorScheme
+ * (Android 12+) 或自定义 lightColorScheme / darkColorScheme (fallback) 生成。
+ */
 
-val Purple40 = Color(0xFF6650a4)
-val PurpleGrey40 = Color(0xFF625b71)
-val Pink40 = Color(0xFF7D5260)
+// Expressive 风格的基础种子色（较 Vibrant，高对比）
+val ExpressivePrimarySeed = Color(0xFF6750A4)   // 深紫
+val ExpressiveSecondarySeed = Color(0xFF625B71) // 紫灰
+val ExpressiveTertiarySeed = Color(0xFF7D5260)  // 玫瑰
+val ExpressiveNeutralSeed = Color(0xFF1C1B1F)   // 深中性
+val ExpressiveNeutralVariantSeed = Color(0xFF49454F) // 中性变体
+
+// Expressive 预调色板 (fallback 静态色彩方案使用)
+// Light Expressive
+val ExpressiveLightPrimary = Color(0xFF6750A4)
+val ExpressiveLightOnPrimary = Color(0xFFFFFFFF)
+val ExpressiveLightPrimaryContainer = Color(0xFFEADDFF)
+val ExpressiveLightOnPrimaryContainer = Color(0xFF21005D)
+
+val ExpressiveLightSecondary = Color(0xFF625B71)
+val ExpressiveLightOnSecondary = Color(0xFFFFFFFF)
+val ExpressiveLightSecondaryContainer = Color(0xFFE8DEF8)
+val ExpressiveLightOnSecondaryContainer = Color(0xFF1D192B)
+
+val ExpressiveLightTertiary = Color(0xFF7D5260)
+val ExpressiveLightOnTertiary = Color(0xFFFFFFFF)
+val ExpressiveLightTertiaryContainer = Color(0xFFFFD8E4)
+val ExpressiveLightOnTertiaryContainer = Color(0xFF31111D)
+
+val ExpressiveLightBackground = Color(0xFFFFFBFE)
+val ExpressiveLightOnBackground = Color(0xFF1C1B1F)
+val ExpressiveLightSurface = Color(0xFFFFFBFE)
+val ExpressiveLightOnSurface = Color(0xFF1C1B1F)
+val ExpressiveLightSurfaceVariant = Color(0xFFE7E0EC)
+val ExpressiveLightOnSurfaceVariant = Color(0xFF49454F)
+
+val ExpressiveLightOutline = Color(0xFF79747E)
+val ExpressiveLightOutlineVariant = Color(0xFFCAC4D0)
+val ExpressiveLightError = Color(0xFFB3261E)
+val ExpressiveLightOnError = Color(0xFFFFFFFF)
+
+val ExpressiveLightSurfaceContainerLowest = Color(0xFFFFFFFF)
+val ExpressiveLightSurfaceContainerLow = Color(0xFFF7F2FA)
+val ExpressiveLightSurfaceContainer = Color(0xFFF3EDF7)
+val ExpressiveLightSurfaceContainerHigh = Color(0xFFECE6F0)
+val ExpressiveLightSurfaceContainerHighest = Color(0xFFE6E0E9)
+
+// Dark Expressive
+val ExpressiveDarkPrimary = Color(0xFFD0BCFF)
+val ExpressiveDarkOnPrimary = Color(0xFF381E72)
+val ExpressiveDarkPrimaryContainer = Color(0xFF4F378B)
+val ExpressiveDarkOnPrimaryContainer = Color(0xFFEADDFF)
+
+val ExpressiveDarkSecondary = Color(0xFFCCC2DC)
+val ExpressiveDarkOnSecondary = Color(0xFF332D41)
+val ExpressiveDarkSecondaryContainer = Color(0xFF4A4458)
+val ExpressiveDarkOnSecondaryContainer = Color(0xFFE8DEF8)
+
+val ExpressiveDarkTertiary = Color(0xFFEFB8C8)
+val ExpressiveDarkOnTertiary = Color(0xFF492532)
+val ExpressiveDarkTertiaryContainer = Color(0xFF633B48)
+val ExpressiveDarkOnTertiaryContainer = Color(0xFFFFD8E4)
+
+val ExpressiveDarkBackground = Color(0xFF1C1B1F)
+val ExpressiveDarkOnBackground = Color(0xFFE6E0E9)
+val ExpressiveDarkSurface = Color(0xFF1C1B1F)
+val ExpressiveDarkOnSurface = Color(0xFFE6E0E9)
+val ExpressiveDarkSurfaceVariant = Color(0xFF49454F)
+val ExpressiveDarkOnSurfaceVariant = Color(0xFFCAC4D0)
+
+val ExpressiveDarkOutline = Color(0xFF938F99)
+val ExpressiveDarkOutlineVariant = Color(0xFF49454F)
+val ExpressiveDarkError = Color(0xFFF2B8B5)
+val ExpressiveDarkOnError = Color(0xFF601410)
+
+val ExpressiveDarkSurfaceContainerLowest = Color(0xFF121114)
+val ExpressiveDarkSurfaceContainerLow = Color(0xFF1C1B1F)
+val ExpressiveDarkSurfaceContainer = Color(0xFF211F26)
+val ExpressiveDarkSurfaceContainerHigh = Color(0xFF2B2930)
+val ExpressiveDarkSurfaceContainerHighest = Color(0xFF36343B)

--- a/app/src/main/java/com/rosan/accounts/ui/theme/Theme.kt
+++ b/app/src/main/java/com/rosan/accounts/ui/theme/Theme.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Shapes
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
@@ -14,6 +15,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.unit.dp
 import androidx.core.view.WindowCompat
 
 /**
@@ -108,6 +110,23 @@ private val ExpressiveDarkColorScheme = darkColorScheme(
     inversePrimary = Color(0xFF6750A4)
 )
 
+/**
+ * Material3 Expressive 风格的 Shape 方案。
+ * Expressive 风格：比默认更圆润，卡片/按钮使用大圆角。
+ *  - extraSmall: 6dp  (默认 4dp)
+ *  - small:      12dp (默认 8dp)
+ *  - medium:     16dp (默认 12dp)
+ *  - large:      28dp (默认 16dp) — 用于卡片、对话框容器
+ *  - extraLarge: 40dp (默认 28dp)
+ */
+private val ExpressiveShapes = Shapes(
+    extraSmall = androidx.compose.foundation.shape.RoundedCornerShape(6.dp),
+    small = androidx.compose.foundation.shape.RoundedCornerShape(12.dp),
+    medium = androidx.compose.foundation.shape.RoundedCornerShape(16.dp),
+    large = androidx.compose.foundation.shape.RoundedCornerShape(28.dp),
+    extraLarge = androidx.compose.foundation.shape.RoundedCornerShape(40.dp)
+)
+
 @Composable
 fun AccountsTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
@@ -132,7 +151,6 @@ fun AccountsTheme(
             val window = (view.context as Activity).window
 
             // 边缘到边缘 (Edge-to-Edge)：让内容延伸到状态栏与导航栏之下
-            // 在 API 30+ 使用系统 inset 控制器；老版本回退到 WindowCompat 实现。
             WindowCompat.setDecorFitsSystemWindows(window, false)
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
@@ -162,6 +180,7 @@ fun AccountsTheme(
     MaterialTheme(
         colorScheme = colorScheme,
         typography = Typography,
+        shapes = ExpressiveShapes,
         content = content
     )
 }

--- a/app/src/main/java/com/rosan/accounts/ui/theme/Theme.kt
+++ b/app/src/main/java/com/rosan/accounts/ui/theme/Theme.kt
@@ -2,7 +2,6 @@ package com.rosan.accounts.ui.theme
 
 import android.app.Activity
 import android.os.Build
-import android.view.WindowManager
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
@@ -17,63 +16,147 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
 
-private val DarkColorScheme = darkColorScheme(
-    primary = Purple80,
-    secondary = PurpleGrey80,
-    tertiary = Pink80
+/**
+ * Material3 Expressive 风格静态色彩方案（ fallback ）。
+ * Expressive 风格：更鲜艳的主色、更明显的三级色对比、更活泼的中性变体。
+ */
+private val ExpressiveLightColorScheme = lightColorScheme(
+    primary = ExpressiveLightPrimary,
+    onPrimary = ExpressiveLightOnPrimary,
+    primaryContainer = ExpressiveLightPrimaryContainer,
+    onPrimaryContainer = ExpressiveLightOnPrimaryContainer,
+
+    secondary = ExpressiveLightSecondary,
+    onSecondary = ExpressiveLightOnSecondary,
+    secondaryContainer = ExpressiveLightSecondaryContainer,
+    onSecondaryContainer = ExpressiveLightOnSecondaryContainer,
+
+    tertiary = ExpressiveLightTertiary,
+    onTertiary = ExpressiveLightOnTertiary,
+    tertiaryContainer = ExpressiveLightTertiaryContainer,
+    onTertiaryContainer = ExpressiveLightOnTertiaryContainer,
+
+    error = ExpressiveLightError,
+    onError = ExpressiveLightOnError,
+    errorContainer = Color(0xFFF9DEDC),
+    onErrorContainer = Color(0xFF410E0B),
+
+    background = ExpressiveLightBackground,
+    onBackground = ExpressiveLightOnBackground,
+
+    surface = ExpressiveLightSurface,
+    onSurface = ExpressiveLightOnSurface,
+    surfaceVariant = ExpressiveLightSurfaceVariant,
+    onSurfaceVariant = ExpressiveLightOnSurfaceVariant,
+
+    outline = ExpressiveLightOutline,
+    outlineVariant = ExpressiveLightOutlineVariant,
+
+    surfaceContainerLowest = ExpressiveLightSurfaceContainerLowest,
+    surfaceContainerLow = ExpressiveLightSurfaceContainerLow,
+    surfaceContainer = ExpressiveLightSurfaceContainer,
+    surfaceContainerHigh = ExpressiveLightSurfaceContainerHigh,
+    surfaceContainerHighest = ExpressiveLightSurfaceContainerHighest,
+
+    scrim = Color(0xFF000000),
+    inverseSurface = Color(0xFF313033),
+    inverseOnSurface = Color(0xFFF4EFF4),
+    inversePrimary = Color(0xFFD0BCFF)
 )
 
-private val LightColorScheme = lightColorScheme(
-    primary = Purple40,
-    secondary = PurpleGrey40,
-    tertiary = Pink40
+private val ExpressiveDarkColorScheme = darkColorScheme(
+    primary = ExpressiveDarkPrimary,
+    onPrimary = ExpressiveDarkOnPrimary,
+    primaryContainer = ExpressiveDarkPrimaryContainer,
+    onPrimaryContainer = ExpressiveDarkOnPrimaryContainer,
 
-    /* Other default colors to override
-    background = Color(0xFFFFFBFE),
-    surface = Color(0xFFFFFBFE),
-    onPrimary = Color.White,
-    onSecondary = Color.White,
-    onTertiary = Color.White,
-    onBackground = Color(0xFF1C1B1F),
-    onSurface = Color(0xFF1C1B1F),
-    */
+    secondary = ExpressiveDarkSecondary,
+    onSecondary = ExpressiveDarkOnSecondary,
+    secondaryContainer = ExpressiveDarkSecondaryContainer,
+    onSecondaryContainer = ExpressiveDarkOnSecondaryContainer,
+
+    tertiary = ExpressiveDarkTertiary,
+    onTertiary = ExpressiveDarkOnTertiary,
+    tertiaryContainer = ExpressiveDarkTertiaryContainer,
+    onTertiaryContainer = ExpressiveDarkOnTertiaryContainer,
+
+    error = ExpressiveDarkError,
+    onError = ExpressiveDarkOnError,
+    errorContainer = Color(0xFF8C1D18),
+    onErrorContainer = Color(0xFFF9DEDC),
+
+    background = ExpressiveDarkBackground,
+    onBackground = ExpressiveDarkOnBackground,
+
+    surface = ExpressiveDarkSurface,
+    onSurface = ExpressiveDarkOnSurface,
+    surfaceVariant = ExpressiveDarkSurfaceVariant,
+    onSurfaceVariant = ExpressiveDarkOnSurfaceVariant,
+
+    outline = ExpressiveDarkOutline,
+    outlineVariant = ExpressiveDarkOutlineVariant,
+
+    surfaceContainerLowest = ExpressiveDarkSurfaceContainerLowest,
+    surfaceContainerLow = ExpressiveDarkSurfaceContainerLow,
+    surfaceContainer = ExpressiveDarkSurfaceContainer,
+    surfaceContainerHigh = ExpressiveDarkSurfaceContainerHigh,
+    surfaceContainerHighest = ExpressiveDarkSurfaceContainerHighest,
+
+    scrim = Color(0xFF000000),
+    inverseSurface = Color(0xFFE6E0E9),
+    inverseOnSurface = Color(0xFF313033),
+    inversePrimary = Color(0xFF6750A4)
 )
 
 @Composable
 fun AccountsTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
-    // Dynamic color is available on Android 12+
+    // 优先使用 Android 12+ 的动态颜色（用户壁纸色彩），Expressive 风格作为 fallback
     dynamicColor: Boolean = true,
     content: @Composable () -> Unit
 ) {
     val colorScheme = when {
         dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
             val context = LocalContext.current
-            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+            if (darkTheme) dynamicDarkColorScheme(context)
+            else dynamicLightColorScheme(context)
         }
 
-        darkTheme -> DarkColorScheme
-        else -> LightColorScheme
+        darkTheme -> ExpressiveDarkColorScheme
+        else -> ExpressiveLightColorScheme
     }
+
     val view = LocalView.current
-    SideEffect {
-        val window = (view.context as Activity).window
+    if (!view.isInEditMode) {
+        SideEffect {
+            val window = (view.context as Activity).window
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P)
-            window.attributes.layoutInDisplayCutoutMode =
-                WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
+            // 边缘到边缘 (Edge-to-Edge)：让内容延伸到状态栏与导航栏之下
+            // 在 API 30+ 使用系统 inset 控制器；老版本回退到 WindowCompat 实现。
+            WindowCompat.setDecorFitsSystemWindows(window, false)
 
-        WindowCompat.setDecorFitsSystemWindows(window, false)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                window.attributes = window.attributes.apply {
+                    layoutInDisplayCutoutMode =
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                            android.view.WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS
+                        } else {
+                            android.view.WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
+                        }
+                }
+            }
 
-        window.statusBarColor = Color.Transparent.toArgb()
-        WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars =
-            !darkTheme
+            // 状态栏透明 + 文字颜色根据主题切换
+            window.statusBarColor = Color.Transparent.toArgb()
+            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = !darkTheme
 
-        window.navigationBarColor = Color.Transparent.toArgb()
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P)
-            window.navigationBarDividerColor = Color.Transparent.toArgb()
-        WindowCompat.getInsetsController(window, view).isAppearanceLightNavigationBars =
-            !darkTheme
+            // 导航栏透明 + 图标颜色根据主题切换
+            window.navigationBarColor = Color.Transparent.toArgb()
+            WindowCompat.getInsetsController(window, view).isAppearanceLightNavigationBars = !darkTheme
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                window.navigationBarDividerColor = Color.Transparent.toArgb()
+            }
+        }
     }
 
     MaterialTheme(

--- a/app/src/main/java/com/rosan/accounts/ui/theme/Type.kt
+++ b/app/src/main/java/com/rosan/accounts/ui/theme/Type.kt
@@ -6,22 +6,118 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 
-// Set of Material typography styles to start with
+/**
+ * Material3 Expressive 风格排版。
+ * Expressive 风格使用更大的标题与更明显的字体大小对比，
+ * 同时对 Display / Headline 采用更高的字重以增强表现力。
+ */
 val Typography = Typography(
+    // Display 系列（最大标题，用于突出的 hero 区域）
+    displayLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.W400,
+        fontSize = 57.sp,
+        lineHeight = 64.sp,
+        letterSpacing = (-0.25).sp
+    ),
+    displayMedium = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.W400,
+        fontSize = 45.sp,
+        lineHeight = 52.sp,
+        letterSpacing = 0.sp
+    ),
+    displaySmall = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.W400,
+        fontSize = 36.sp,
+        lineHeight = 44.sp,
+        letterSpacing = 0.sp
+    ),
+
+    // Headline 系列（高影响力的小节标题，Expressive 风格采用 Medium 字重）
+    headlineLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Medium,
+        fontSize = 32.sp,
+        lineHeight = 40.sp,
+        letterSpacing = 0.sp
+    ),
+    headlineMedium = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Medium,
+        fontSize = 28.sp,
+        lineHeight = 36.sp,
+        letterSpacing = 0.sp
+    ),
+    headlineSmall = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Medium,
+        fontSize = 24.sp,
+        lineHeight = 32.sp,
+        letterSpacing = 0.sp
+    ),
+
+    // Title 系列
+    titleLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Medium,
+        fontSize = 22.sp,
+        lineHeight = 28.sp,
+        letterSpacing = 0.sp
+    ),
+    titleMedium = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Medium,
+        fontSize = 16.sp,
+        lineHeight = 24.sp,
+        letterSpacing = 0.15.sp
+    ),
+    titleSmall = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Medium,
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+        letterSpacing = 0.1.sp
+    ),
+
+    // Body 系列（主要正文）
     bodyLarge = TextStyle(
         fontFamily = FontFamily.Default,
         fontWeight = FontWeight.Normal,
         fontSize = 16.sp,
         lineHeight = 24.sp,
         letterSpacing = 0.5.sp
-    )
-    /* Other default text styles to override
-    titleLarge = TextStyle(
+    ),
+    bodyMedium = TextStyle(
         fontFamily = FontFamily.Default,
         fontWeight = FontWeight.Normal,
-        fontSize = 22.sp,
-        lineHeight = 28.sp,
-        letterSpacing = 0.sp
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+        letterSpacing = 0.25.sp
+    ),
+    bodySmall = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 12.sp,
+        lineHeight = 16.sp,
+        letterSpacing = 0.4.sp
+    ),
+
+    // Label 系列（按钮、chip 等标签）
+    labelLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Medium,
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+        letterSpacing = 0.1.sp
+    ),
+    labelMedium = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Medium,
+        fontSize = 12.sp,
+        lineHeight = 16.sp,
+        letterSpacing = 0.5.sp
     ),
     labelSmall = TextStyle(
         fontFamily = FontFamily.Default,
@@ -30,5 +126,4 @@ val Typography = Typography(
         lineHeight = 16.sp,
         letterSpacing = 0.5.sp
     )
-    */
 )

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -3,7 +3,7 @@
     <string name="user_name_default">未命名用户</string>
     <string name="current_user_label">当前用户</string>
     <string name="other_user_label">其他用户</string>
-    <string name="user_id_format">编号：%1$d</string>
+    <string name="user_id_format" formatted="false">编号：%1$d</string>
     <string name="remove_user_title">移除用户</string>
 
     <string name="delete_user_warning">确定要移除该用户吗？此用户空间内的所有账号和应用数据将被永久清除。</string>
@@ -14,7 +14,7 @@
     <string name="account_manager">账号管理</string>
     <string name="account_empty">暂无账号</string>
     <string name="account_empty_hint">该用户空间内应用添加的账号会显示在这里。</string>
-    <string name="linked_accounts_count">已关联 %1$d 个账号</string>
+    <string name="linked_accounts_count" formatted="false">已关联 %1$d 个账号</string>
     <string name="copied_format_hail">复制成功！请在【雹】中粘贴。</string>
     <string name="copy_packages_cd">复制包名</string>
     <string name="shizuku_not_working">请激活 Shizuku 并授权。</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="user_manager">用户管理</string>
     <string name="user_name_default">未命名用户</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1,19 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="user_manager">用户管理</string>
-    <string name="user_name_default">未命名</string>
+    <string name="user_name_default">未命名用户</string>
     <string name="current_user_label">当前用户</string>
     <string name="other_user_label">其他用户</string>
+    <string name="user_id_format">编号：%1$d</string>
+    <string name="remove_user_title">移除用户</string>
 
-    <string name="delete_user_warning">确定要删除此用户吗？\n所有处于此用户空间的应用和数据都会消失！！！</string>
-    <string name="delete_user_confirm">是的，我确定！</string>
+    <string name="delete_user_warning">确定要移除该用户吗？此用户空间内的所有账号和应用数据将被永久清除。</string>
+    <string name="delete_user_confirm">确认移除</string>
     <string name="delete_user_cancel">取消</string>
 
     <string name="remove">移除</string>
     <string name="account_manager">账号管理</string>
     <string name="account_empty">暂无账号</string>
-    <string name="copied_format_hail">复制成功，请在【雹】中导入！</string>
-    <string name="copy_packages_cd">复制包名</string>
+    <string name="account_empty_hint">该用户空间内应用添加的账号会显示在这里。</string>
     <string name="linked_accounts_count">已关联 %1$d 个账号</string>
-    <string name="shizuku_not_working">请激活 Shizuku 并同意权限请求！</string>
+    <string name="copied_format_hail">复制成功！请在【雹】中粘贴。</string>
+    <string name="copy_packages_cd">复制包名</string>
+    <string name="shizuku_not_working">请激活 Shizuku 并授权。</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -2,14 +2,18 @@
 <resources>
     <string name="user_manager">用户管理</string>
     <string name="user_name_default">未命名</string>
+    <string name="current_user_label">当前用户</string>
+    <string name="other_user_label">其他用户</string>
 
     <string name="delete_user_warning">确定要删除此用户吗？\n所有处于此用户空间的应用和数据都会消失！！！</string>
     <string name="delete_user_confirm">是的，我确定！</string>
-
     <string name="delete_user_cancel">取消</string>
+
     <string name="remove">移除</string>
     <string name="account_manager">账号管理</string>
-    <string name="account_empty">没有账户存在</string>
+    <string name="account_empty">暂无账号</string>
     <string name="copied_format_hail">复制成功，请在【雹】中导入！</string>
-    <string name="shizuku_not_working">请激活Shizuku并同意权限请求！</string>
+    <string name="copy_packages_cd">复制包名</string>
+    <string name="linked_accounts_count">已关联 %1$d 个账号</string>
+    <string name="shizuku_not_working">请激活 Shizuku 并同意权限请求！</string>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="purple_200">#FFBB86FC</color>
-    <color name="purple_500">#FF6200EE</color>
-    <color name="purple_700">#FF3700B3</color>
-    <color name="teal_200">#FF03DAC5</color>
-    <color name="teal_700">#FF018786</color>
-    <color name="black">#FF000000</color>
-    <color name="white">#FFFFFFFF</color>
+    <!-- Material3 Expressive 风格 window 背景颜色（浅色 fallback）
+         注意：应用内 Compose UI 会覆盖此背景，这里只是保证加载瞬间的色调一致。 -->
+    <color name="m3_window_background">#FFFFFBFE</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,6 +3,8 @@
 
     <string name="user_manager">User Manager</string>
     <string name="user_name_default">Untitled</string>
+    <string name="current_user_label">Current user</string>
+    <string name="other_user_label">Other user</string>
 
     <string name="delete_user_warning">Are you sure you want to delete this user space?\nAll applications and data in this user space will be lost!!!</string>
     <string name="delete_user_confirm">Yes, I\'m sure!</string>
@@ -11,7 +13,9 @@
     <string name="remove">Remove</string>
 
     <string name="account_manager">Account Manager</string>
-    <string name="account_empty">No account exists</string>
-    <string name="copied_format_hail">copied, import it in Hail!</string>
+    <string name="account_empty">No accounts</string>
+    <string name="copied_format_hail">Copied, import it in Hail!</string>
+    <string name="copy_packages_cd">Copy package names</string>
+    <string name="linked_accounts_count">%1$d linked account(s)</string>
     <string name="shizuku_not_working">Please activate Shizuku and agree to grant permission.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,7 +5,7 @@
     <string name="user_name_default">Untitled User</string>
     <string name="current_user_label">Current user</string>
     <string name="other_user_label">Other user</string>
-    <string name="user_id_format">ID: %1$d</string>
+    <string name="user_id_format" formatted="false">ID: %1$d</string>
     <string name="remove_user_title">Remove user</string>
 
     <string name="delete_user_warning">Are you sure you want to remove this user? All accounts and data associated with this user space will be permanently lost.</string>
@@ -17,7 +17,7 @@
     <string name="account_manager">Account Manager</string>
     <string name="account_empty">No accounts yet</string>
     <string name="account_empty_hint">Accounts added by apps in this user space will appear here.</string>
-    <string name="linked_accounts_count">%1$d linked account(s)</string>
+    <string name="linked_accounts_count" formatted="false">%1$d linked account(s)</string>
     <string name="copied_format_hail">Copied! Paste into Hail.</string>
     <string name="copy_packages_cd">Copy package names</string>
     <string name="shizuku_not_working">Please activate Shizuku and grant permission.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,20 +2,23 @@
     <string name="app_name" translatable="false">Accounts</string>
 
     <string name="user_manager">User Manager</string>
-    <string name="user_name_default">Untitled</string>
+    <string name="user_name_default">Untitled User</string>
     <string name="current_user_label">Current user</string>
     <string name="other_user_label">Other user</string>
+    <string name="user_id_format">ID: %1$d</string>
+    <string name="remove_user_title">Remove user</string>
 
-    <string name="delete_user_warning">Are you sure you want to delete this user space?\nAll applications and data in this user space will be lost!!!</string>
-    <string name="delete_user_confirm">Yes, I\'m sure!</string>
-    <string name="delete_user_cancel">No</string>
+    <string name="delete_user_warning">Are you sure you want to remove this user? All accounts and data associated with this user space will be permanently lost.</string>
+    <string name="delete_user_confirm">Yes, remove</string>
+    <string name="delete_user_cancel">Cancel</string>
 
     <string name="remove">Remove</string>
 
     <string name="account_manager">Account Manager</string>
-    <string name="account_empty">No accounts</string>
-    <string name="copied_format_hail">Copied, import it in Hail!</string>
-    <string name="copy_packages_cd">Copy package names</string>
+    <string name="account_empty">No accounts yet</string>
+    <string name="account_empty_hint">Accounts added by apps in this user space will appear here.</string>
     <string name="linked_accounts_count">%1$d linked account(s)</string>
-    <string name="shizuku_not_working">Please activate Shizuku and agree to grant permission.</string>
+    <string name="copied_format_hail">Copied! Paste into Hail.</string>
+    <string name="copy_packages_cd">Copy package names</string>
+    <string name="shizuku_not_working">Please activate Shizuku and grant permission.</string>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,8 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
+    <!-- Material3 Expressive 基线主题。实际颜色由 Compose Material3 动态颜色/静态方案决定。
+         这里仅声明 Activity/应用级别的 window 背景（边缘到边缘）。 -->
     <style name="Theme.Accounts" parent="android:Theme.Material.Light.NoActionBar">
-        <item name="android:windowTranslucentStatus">true</item>
-        <item name="android:windowTranslucentNavigation">true</item>
+        <item name="android:windowBackground">@color/m3_window_background</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+        <item name="android:windowTranslucentStatus">false</item>
+        <item name="android:windowTranslucentNavigation">false</item>
+        <item name="android:enforceNavigationBarContrast">false</item>
+        <item name="android:enforceStatusBarContrast">false</item>
     </style>
+
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '8.0.2' apply false
-    id 'com.android.library' version '8.0.2' apply false
-    id 'org.jetbrains.kotlin.android' version '1.8.20' apply false
+    id 'com.android.application' version '8.1.4' apply false
+    id 'com.android.library' version '8.1.4' apply false
+    id 'org.jetbrains.kotlin.android' version '1.9.20' apply false
 }


### PR DESCRIPTION
- Upgrade dependencies: Kotlin 1.9.20, Compose BOM 2024.02, Material3 1.6+, Navigation 2.7.7, compileSdk 34
- Implement Expressive color scheme with deep purple primary + rose tertiary
- Full 15-style Material3 typography (display/headline/title/body/label)
- Edge-to-edge immersive UI with transparent status/nav bars
- UserManagerPage: LargeTopAppBar with collapse behavior, Card list, AssistChip, FilledTonalButton, color-themed delete dialog
- AccountManagerPage: LargeTopAppBar, Card list with icon container, empty-state illustration, linked-accounts count
- Update themes.xml/colors.xml for M3 window background
- Add new string resources (en + zh-rCN)